### PR TITLE
gitignore configure~ and config.h.in~

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config.log
 config.status
 config.sub
 configure
+configure~
 depcomp
 doc/Makefile
 doc/Makefile.in


### PR DESCRIPTION
Add the "configure~" and "config.h.in~" files to .gitignore. These files are produced after running "bootstrap" more than once, and don't need to be committed.