### PR TITLE
Deterministically wait for hotplug_libusb shutdown

### DIFF
--- a/src/hotplug_libusb.c
+++ b/src/hotplug_libusb.c
@@ -581,7 +581,7 @@ LONG HPSearchHotPluggables(const char * hpDirPath)
 			return -1;
 		}
 
-		ThreadCreate(&usbNotifyThread, THREAD_ATTR_DETACHED,
+		ThreadCreate(&usbNotifyThread, 0,
 			(PCSCLITE_THREAD_FUNCTION( )) HPEstablishUSBNotifications, pipefd);
 
 		/* Wait for initial readers to setup */
@@ -601,12 +601,16 @@ LONG HPSearchHotPluggables(const char * hpDirPath)
 
 LONG HPStopHotPluggables(void)
 {
+	/* tell the rescan thread to shut down; it checks the ara kiri flag, but it
+	 * might also need to be awaken from reading the rescan pipe */
 	AraKiriHotPlug = true;
 	if (rescan_pipe[1] >= 0)
 	{
 		close(rescan_pipe[1]);
 		rescan_pipe[1] = -1;
 	}
+	/* wait for the rescan thread to complete its cleanup */
+	pthread_join(usbNotifyThread, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
Change HPStopHotPluggables() to actually wait until the background hotplug thread exits.

This makes sure that the hotplug mechanism doesn't continue working throughout the daemon's shutdown process, and hence use-after-frees (if a reader is added/removed after the readerfactory is shut down), memory leaks etc. are prevented.

Note: this is expected to make the "SYS_Sleep(1)" trick in pcscdaemon.c unnecessary, replacing it with a more reliable alternative. We don't delete the sleep in the same commit in case it turns out to be crucial for some other reason.